### PR TITLE
Add version to provider info

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -61,6 +61,7 @@ func Provider(ctx context.Context) tfbridge.ProviderInfo {
 		Homepage:          "https://www.pulumi.com",
 		Repository:        "https://github.com/pulumi/pulumi-dbtcloud",
 		GitHubOrg:         "dbt-labs",
+		Version:           version.Version,
 		LogoURL:           "https://raw.githubusercontent.com/pulumi/pulumi-dbtcloud/main/res/dbt-bit_tm.png",
 		TFProviderLicense: tfbridge.SetProviderLicense(tfbridge.MITLicenseType),
 		MetadataInfo:      tfbridge.NewProviderMetadata(bridgeMetadata),

--- a/sdk/dotnet/Pulumi.DbtCloud.csproj
+++ b/sdk/dotnet/Pulumi.DbtCloud.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://www.pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-dbtcloud</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <Version>0.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,6 @@
 {
   "resource": true,
   "name": "dbtcloud",
+  "version": "0.0.0-alpha.0+dev",
   "server": "github://api.github.com/pulumi/pulumi-dbtcloud"
 }

--- a/sdk/go/dbtcloud/internal/pulumiUtilities.go
+++ b/sdk/go/dbtcloud/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/pulumi/pulumi-dbtcloud"))
-	version := SdkVersion
+	version := semver.MustParse("0.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/pulumi/pulumi-dbtcloud"))
-	version := SdkVersion
+	version := semver.MustParse("0.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/dbtcloud/pulumi-plugin.json
+++ b/sdk/go/dbtcloud/pulumi-plugin.json
@@ -1,5 +1,6 @@
 {
   "resource": true,
   "name": "dbtcloud",
+  "version": "0.0.0-alpha.0+dev",
   "server": "github://api.github.com/pulumi/pulumi-dbtcloud"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/dbtcloud",
-    "version": "${VERSION}",
+    "version": "0.0.0-alpha.0+dev",
     "description": "A Pulumi package for creating and managing dbt Cloud resources.",
     "keywords": [
         "pulumi",
@@ -26,6 +26,7 @@
     "pulumi": {
         "resource": true,
         "name": "dbtcloud",
+        "version": "0.0.0-alpha.0+dev",
         "server": "github://api.github.com/pulumi/pulumi-dbtcloud"
     }
 }

--- a/sdk/python/pulumi_dbtcloud/pulumi-plugin.json
+++ b/sdk/python/pulumi_dbtcloud/pulumi-plugin.json
@@ -1,5 +1,6 @@
 {
   "resource": true,
   "name": "dbtcloud",
+  "version": "0.0.0-alpha.0+dev",
   "server": "github://api.github.com/pulumi/pulumi-dbtcloud"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["pulumi", "dbtcloud", "dbt", "cloud", "category/cloud"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "0.0.0"
+  version = "0.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-dbtcloud/issues/15

As found by @danielrbradley, https://github.com/pulumi/pulumi-dbtcloud/pull/14/files#diff-9622900b6c234a19b0163793f4f3087f0004e38e5db3991f3ec03fcf4aa1c5ffL33 broke the versioning as it depends on the version in the providerInfo instead of an explicitly passed one to the Main function.