### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -316,6 +316,7 @@ func Provider(ctx context.Context) tfbridge.ProviderInfo {
 				"Pulumi": "3.*",
 			},
 		},
+		EnableAccurateBridgePreview: true,
 	}
 
 	prov.MustComputeTokens(


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the pulumi-dbtcloud provider. This should improve the quality of our previews for the provider.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598